### PR TITLE
Chart: Always show all labels

### DIFF
--- a/src/main/java/org/kickerelo/kickerelo/views/Chart.java
+++ b/src/main/java/org/kickerelo/kickerelo/views/Chart.java
@@ -30,6 +30,10 @@ public class Chart extends Component {
         // Font size
         js += "Chart.defaults.font.size = 16;";
 
+        // Scales
+        js += "Chart.defaults.scales.category.ticks.autoSkip = false;";
+        js += "Chart.defaults.scales.category.offset = true;";
+
         // Chart
         js += "new Chart(document.getElementById('chart'), {type: 'line', ";
         js += "options: {showLine: false, pointRadius: 7, plugins: { legend: { display: false}}, layout: { padding: 10}}, ";


### PR DESCRIPTION
This fixes that not all player names show up on mobile view.

Also adds an offset to the start and the end, so that the first and the last names aren't directly on the border.