### PR TITLE
views: Add checkbox to only show active players

### DIFF
--- a/src/main/java/org/kickerelo/kickerelo/repository/Ergebnis1vs1Repository.java
+++ b/src/main/java/org/kickerelo/kickerelo/repository/Ergebnis1vs1Repository.java
@@ -1,6 +1,7 @@
 package org.kickerelo.kickerelo.repository;
 
 import org.kickerelo.kickerelo.data.Ergebnis1vs1;
+import org.kickerelo.kickerelo.data.Spieler;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,4 +19,7 @@ public interface Ergebnis1vs1Repository extends JpaRepository<Ergebnis1vs1, Long
         (:S1 IS NULL AND :S2 IS NULL)
     """)
     List<Ergebnis1vs1> getFiltered(@Param("S1") String s1, @Param("S2") String s2);
+
+    @Query("select e from Ergebnis1vs1 e where (:s = e.verlierer or :s = e.gewinner) order by e.timestamp desc")
+    List<Ergebnis1vs1> getResultsForSpieler(@Param("s") Spieler s);
 }

--- a/src/main/java/org/kickerelo/kickerelo/repository/SpielerRepository.java
+++ b/src/main/java/org/kickerelo/kickerelo/repository/SpielerRepository.java
@@ -3,8 +3,10 @@ package org.kickerelo.kickerelo.repository;
 import org.kickerelo.kickerelo.data.Spieler;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,10 +14,23 @@ import java.util.Optional;
 public interface SpielerRepository extends JpaRepository<Spieler, Long> {
     Optional<Spieler> findByName(String name);
 
-    @Query("SELECT s FROM Spieler s WHERE EXISTS (SELECT 1 FROM Ergebnis1vs1 e WHERE e.gewinner=s OR e.verlierer=s)")
+    @Query("SELECT s FROM Spieler s WHERE EXISTS (SELECT 1 FROM Ergebnis1vs1 e WHERE e.gewinner=s OR e.verlierer=s) " +
+            "order by s.elo1vs1 desc ")
     List<Spieler> getSpielerWith1vs1Games();
 
     @Query("SELECT s FROM Spieler s WHERE EXISTS (SELECT 1 FROM Ergebnis2vs2 e " +
-            "WHERE e.gewinnerVorn=s OR e.verliererVorn=s OR e.gewinnerHinten=s OR e.verliererHinten=s)")
+            "WHERE e.gewinnerVorn=s OR e.verliererVorn=s OR e.gewinnerHinten=s OR e.verliererHinten=s) " +
+            "order by s.elo2vs2 desc")
     List<Spieler> getSpielerWith2vs2Games();
+
+    @Query("select distinct s from Spieler s join Ergebnis1vs1 e on (s = e.verlierer or s = e.gewinner) " +
+            "where e.timestamp >= :dateTime " +
+            "order by s.elo1vs1 desc")
+    List<Spieler> getSpielerWith1vs1GamesSince(@Param("dateTime") LocalDateTime dateTime);
+
+    @Query("select distinct s from Spieler s join Ergebnis2vs2 e " +
+            "on (s = e.verliererVorn or s = e.gewinnerVorn or s = e.verliererHinten or s = e.gewinnerHinten) " +
+            "where e.timestamp >= :dateTime " +
+            "order by s.elo2vs2 desc")
+    List<Spieler> getSpielerWith2vs2GamesSince(@Param("dateTime") LocalDateTime dateTime);
 }

--- a/src/main/java/org/kickerelo/kickerelo/views/Graph1vs1View.java
+++ b/src/main/java/org/kickerelo/kickerelo/views/Graph1vs1View.java
@@ -39,7 +39,7 @@ public class Graph1vs1View extends VerticalLayout {
         List<String> names = new ArrayList<>();
         List<Float> elo = new ArrayList<>();
 
-        List<Spieler> spieler = (onlyActive) ?
+        List<Spieler> spieler = onlyActive ?
                 spielerRepository.getSpielerWith1vs1GamesSince(LocalDateTime.now().minusWeeks(4))
                 : spielerRepository.getSpielerWith1vs1Games();
 

--- a/src/main/java/org/kickerelo/kickerelo/views/Graph1vs1View.java
+++ b/src/main/java/org/kickerelo/kickerelo/views/Graph1vs1View.java
@@ -4,23 +4,19 @@ import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
-import org.kickerelo.kickerelo.repository.Ergebnis1vs1Repository;
+import org.kickerelo.kickerelo.data.Spieler;
 import org.kickerelo.kickerelo.repository.SpielerRepository;
-import org.kickerelo.kickerelo.util.comparator.Spieler1vs1EloComparator;
 
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
 @Route("graph1vs1")
 public class Graph1vs1View extends VerticalLayout {
-    private final Ergebnis1vs1Repository ergebnisRepository;
     private final SpielerRepository spielerRepository;
     private Chart chart;
 
-    public Graph1vs1View(Ergebnis1vs1Repository ergebnisRepository, SpielerRepository spielerRepository) {
-        this.ergebnisRepository = ergebnisRepository;
+    public Graph1vs1View(SpielerRepository spielerRepository) {
         this.spielerRepository = spielerRepository;
         setSizeFull();
         H2 subheading = new H2("1 vs 1 Elo");
@@ -43,22 +39,12 @@ public class Graph1vs1View extends VerticalLayout {
         List<String> names = new ArrayList<>();
         List<Float> elo = new ArrayList<>();
 
-        spielerRepository.getSpielerWith1vs1Games().stream()
-                .filter((spieler) -> {
-                    if (!onlyActive) {
-                        return true;
-                    }
+        List<Spieler> spieler = (onlyActive) ?
+                spielerRepository.getSpielerWith1vs1GamesSince(LocalDateTime.now().minusWeeks(4))
+                : spielerRepository.getSpielerWith1vs1Games();
 
-                    var results = ergebnisRepository.getResultsForSpieler(spieler);
-                    return results.stream().anyMatch((result) -> {
-                        var twoWeeksAgo = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS).minusWeeks(2);
-                        return result.getTimestamp().isAfter(twoWeeksAgo);
-                    });
-                })
-                .sorted(new Spieler1vs1EloComparator()).forEach((s) -> {
-                    names.add(s.getName());
-                    elo.add(s.getElo1vs1());
-                });
+        spieler.forEach((s) -> {names.add(s.getName()); elo.add(s.getElo1vs1());});
+
         return new Chart(names, elo);
     }
 }

--- a/src/main/java/org/kickerelo/kickerelo/views/Graph1vs1View.java
+++ b/src/main/java/org/kickerelo/kickerelo/views/Graph1vs1View.java
@@ -1,29 +1,64 @@
 package org.kickerelo.kickerelo.views;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.kickerelo.kickerelo.repository.SpielerRepository;
-import org.kickerelo.kickerelo.util.comparator.Spieler1vs1EloComparator;
-
+import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
+import org.kickerelo.kickerelo.repository.Ergebnis1vs1Repository;
+import org.kickerelo.kickerelo.repository.SpielerRepository;
+import org.kickerelo.kickerelo.util.comparator.Spieler1vs1EloComparator;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 
 @Route("graph1vs1")
 public class Graph1vs1View extends VerticalLayout {
+    private final Ergebnis1vs1Repository ergebnisRepository;
+    private final SpielerRepository spielerRepository;
+    private Chart chart;
 
-    public Graph1vs1View(SpielerRepository repo) {
+    public Graph1vs1View(Ergebnis1vs1Repository ergebnisRepository, SpielerRepository spielerRepository) {
+        this.ergebnisRepository = ergebnisRepository;
+        this.spielerRepository = spielerRepository;
         setSizeFull();
         H2 subheading = new H2("1 vs 1 Elo");
 
+        Checkbox checkbox = new Checkbox();
+        checkbox.setValue(true);
+        checkbox.addValueChangeListener(event -> {
+            remove(chart);
+            chart = createChart(event.getValue());
+            add(chart);
+        });
+        checkbox.setLabel("Nur aktive Spieler*innen anzeigen");
+        checkbox.setTooltipText("Nur Spieler*innen anzeigen, die in den letzten 2 Wochen gespielt haben");
+        chart = createChart(true);
+
+        add(subheading, checkbox, chart);
+    }
+
+    private Chart createChart(boolean onlyActive) {
         List<String> names = new ArrayList<>();
         List<Float> elo = new ArrayList<>();
 
-        repo.getSpielerWith1vs1Games().stream().sorted(new Spieler1vs1EloComparator()).forEach((s) -> {names.add(s.getName()); elo.add(s.getElo1vs1());});
+        spielerRepository.getSpielerWith1vs1Games().stream()
+                .filter((spieler) -> {
+                    if (!onlyActive) {
+                        return true;
+                    }
 
-        Chart chart = new Chart(names, elo);
-
-        add(subheading, chart);
+                    var results = ergebnisRepository.getResultsForSpieler(spieler);
+                    return results.stream().anyMatch((result) -> {
+                        var twoWeeksAgo = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS).minusWeeks(2);
+                        return result.getTimestamp().isAfter(twoWeeksAgo);
+                    });
+                })
+                .sorted(new Spieler1vs1EloComparator()).forEach((s) -> {
+                    names.add(s.getName());
+                    elo.add(s.getElo1vs1());
+                });
+        return new Chart(names, elo);
     }
 }

--- a/src/main/java/org/kickerelo/kickerelo/views/Graph1vs1View.java
+++ b/src/main/java/org/kickerelo/kickerelo/views/Graph1vs1View.java
@@ -29,7 +29,7 @@ public class Graph1vs1View extends VerticalLayout {
             add(chart);
         });
         checkbox.setLabel("Nur aktive Spieler*innen anzeigen");
-        checkbox.setTooltipText("Nur Spieler*innen anzeigen, die in den letzten 2 Wochen gespielt haben");
+        checkbox.setTooltipText("Nur Spieler*innen anzeigen, die in den letzten 4 Wochen gespielt haben");
         chart = createChart(true);
 
         add(subheading, checkbox, chart);

--- a/src/main/java/org/kickerelo/kickerelo/views/Graph2vs2View.java
+++ b/src/main/java/org/kickerelo/kickerelo/views/Graph2vs2View.java
@@ -29,7 +29,7 @@ public class Graph2vs2View extends VerticalLayout {
             add(chart);
         });
         checkbox.setLabel("Nur aktive Spieler*innen anzeigen");
-        checkbox.setTooltipText("Nur Spieler*innen anzeigen, die in den letzten 2 Wochen gespielt haben");
+        checkbox.setTooltipText("Nur Spieler*innen anzeigen, die in den letzten 4 Wochen gespielt haben");
         chart = createChart(true);
 
         add(subheading, checkbox, chart);

--- a/src/main/java/org/kickerelo/kickerelo/views/Graph2vs2View.java
+++ b/src/main/java/org/kickerelo/kickerelo/views/Graph2vs2View.java
@@ -4,23 +4,19 @@ import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
-import org.kickerelo.kickerelo.repository.Ergebnis2vs2Repository;
+import org.kickerelo.kickerelo.data.Spieler;
 import org.kickerelo.kickerelo.repository.SpielerRepository;
-import org.kickerelo.kickerelo.util.comparator.Spieler2vs2EloComparator;
 
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
 @Route("graph2vs2")
 public class Graph2vs2View extends VerticalLayout {
-    private final Ergebnis2vs2Repository ergebnisRepository;
     private final SpielerRepository spielerRepository;
     private Chart chart;
 
-    public Graph2vs2View(Ergebnis2vs2Repository ergebnisRepository, SpielerRepository spielerRepository) {
-        this.ergebnisRepository = ergebnisRepository;
+    public Graph2vs2View(SpielerRepository spielerRepository) {
         this.spielerRepository = spielerRepository;
         setSizeFull();
         H2 subheading = new H2("2 vs 2 Elo");
@@ -43,22 +39,12 @@ public class Graph2vs2View extends VerticalLayout {
         List<String> names = new ArrayList<>();
         List<Float> elo = new ArrayList<>();
 
-        spielerRepository.getSpielerWith2vs2Games().stream()
-                .filter((spieler) -> {
-                    if (!onlyActive) {
-                        return true;
-                    }
+        List<Spieler> spieler = (onlyActive) ?
+                spielerRepository.getSpielerWith2vs2GamesSince(LocalDateTime.now().minusWeeks(4))
+                : spielerRepository.getSpielerWith2vs2Games();
 
-                    var results = ergebnisRepository.getResultsForSpieler(spieler);
-                    return results.stream().anyMatch((result) -> {
-                        var twoWeeksAgo = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS).minusWeeks(2);
-                        return result.getTimestamp().isAfter(twoWeeksAgo);
-                    });
-                })
-                .sorted(new Spieler2vs2EloComparator()).forEach((s) -> {
-                    names.add(s.getName());
-                    elo.add(s.getElo2vs2());
-                });
+        spieler.forEach((s) -> {names.add(s.getName()); elo.add(s.getElo2vs2());});
+
         return new Chart(names, elo);
     }
 }

--- a/src/main/java/org/kickerelo/kickerelo/views/Graph2vs2View.java
+++ b/src/main/java/org/kickerelo/kickerelo/views/Graph2vs2View.java
@@ -39,7 +39,7 @@ public class Graph2vs2View extends VerticalLayout {
         List<String> names = new ArrayList<>();
         List<Float> elo = new ArrayList<>();
 
-        List<Spieler> spieler = (onlyActive) ?
+        List<Spieler> spieler = onlyActive ?
                 spielerRepository.getSpielerWith2vs2GamesSince(LocalDateTime.now().minusWeeks(4))
                 : spielerRepository.getSpielerWith2vs2Games();
 

--- a/src/main/java/org/kickerelo/kickerelo/views/Graph2vs2View.java
+++ b/src/main/java/org/kickerelo/kickerelo/views/Graph2vs2View.java
@@ -1,29 +1,64 @@
 package org.kickerelo.kickerelo.views;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.kickerelo.kickerelo.repository.SpielerRepository;
-import org.kickerelo.kickerelo.util.comparator.Spieler2vs2EloComparator;
-
+import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
+import org.kickerelo.kickerelo.repository.Ergebnis2vs2Repository;
+import org.kickerelo.kickerelo.repository.SpielerRepository;
+import org.kickerelo.kickerelo.util.comparator.Spieler2vs2EloComparator;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 
 @Route("graph2vs2")
 public class Graph2vs2View extends VerticalLayout {
+    private final Ergebnis2vs2Repository ergebnisRepository;
+    private final SpielerRepository spielerRepository;
+    private Chart chart;
 
-    public Graph2vs2View(SpielerRepository repo) {
+    public Graph2vs2View(Ergebnis2vs2Repository ergebnisRepository, SpielerRepository spielerRepository) {
+        this.ergebnisRepository = ergebnisRepository;
+        this.spielerRepository = spielerRepository;
         setSizeFull();
         H2 subheading = new H2("2 vs 2 Elo");
 
+        Checkbox checkbox = new Checkbox();
+        checkbox.setValue(true);
+        checkbox.addValueChangeListener(event -> {
+            remove(chart);
+            chart = createChart(event.getValue());
+            add(chart);
+        });
+        checkbox.setLabel("Nur aktive Spieler*innen anzeigen");
+        checkbox.setTooltipText("Nur Spieler*innen anzeigen, die in den letzten 2 Wochen gespielt haben");
+        chart = createChart(true);
+
+        add(subheading, checkbox, chart);
+    }
+
+    private Chart createChart(boolean onlyActive) {
         List<String> names = new ArrayList<>();
         List<Float> elo = new ArrayList<>();
 
-        repo.getSpielerWith2vs2Games().stream().sorted(new Spieler2vs2EloComparator()).forEach((s) -> {names.add(s.getName()); elo.add(s.getElo2vs2());});
+        spielerRepository.getSpielerWith2vs2Games().stream()
+                .filter((spieler) -> {
+                    if (!onlyActive) {
+                        return true;
+                    }
 
-        Chart chart = new Chart(names, elo);
-
-        add(subheading, chart);
+                    var results = ergebnisRepository.getResultsForSpieler(spieler);
+                    return results.stream().anyMatch((result) -> {
+                        var twoWeeksAgo = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS).minusWeeks(2);
+                        return result.getTimestamp().isAfter(twoWeeksAgo);
+                    });
+                })
+                .sorted(new Spieler2vs2EloComparator()).forEach((s) -> {
+                    names.add(s.getName());
+                    elo.add(s.getElo2vs2());
+                });
+        return new Chart(names, elo);
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -126,7 +126,7 @@ INSERT INTO ergebnis1vs1 (id, gewinner, verlierer, tore_verlierer, zeitpunkt) VA
     (97, 5, 2, 1, '2025-03-07 10:45:00'),
     (98, 10, 24, 0, '2025-03-08 12:00:00'),
     (99, 14, 12, 5, '2025-03-09 14:15:00'),
-    (100, 23, 7, 3, '2025-03-10 16:30:00');
+    (100, 23, 7, 3, '2025-09-04 16:30:00');
 
 INSERT INTO ergebnis2vs2 (id, gewinner_vorn, gewinner_hinten, verlierer_vorn, verlierer_hinten, tore_verlierer, zeitpunkt) VALUES
     (1, 5, 12, 1, 18, 2, '2024-11-01 10:00:00'),
@@ -228,4 +228,4 @@ INSERT INTO ergebnis2vs2 (id, gewinner_vorn, gewinner_hinten, verlierer_vorn, ve
     (97, 6, 1, 18, 14, 1, '2025-03-07 10:45:00'),
     (98, 19, 23, 7, 25, 0, '2025-03-08 12:00:00'),
     (99, 11, 26, 22, 3, 5, '2025-03-09 14:15:00'),
-    (100, 16, 12, 5, 17, 3, '2025-03-10 16:30:00');
+    (100, 16, 12, 5, 17, 3, '2025-09-07 16:30:00');


### PR DESCRIPTION
Enabled by default, this changes the Elo graphs to only show players that played a game (in the respective category) in the last 2 weeks.

Testing: WOMM

Screenshots:

<img width="1449" height="795" alt="image" src="https://github.com/user-attachments/assets/b30900af-4c5e-4828-b23c-98c27d0da6bc" />
<img width="1445" height="745" alt="image" src="https://github.com/user-attachments/assets/8e4ef5da-05cc-410c-ab8b-c5c8905d7b64" />

Closes #84 